### PR TITLE
Added resolve nuget.exe from path

### DIFF
--- a/res/scripts/build.ps1
+++ b/res/scripts/build.ps1
@@ -9,6 +9,16 @@ $TOOLS_DIR = Join-Path $PSScriptRoot "tools"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
 
+# Try find NuGet.exe in path if not exists
+if (!(Test-Path $NUGET_EXE)) {
+    "Trying to find nuget.exe in path"
+    $NUGET_EXE_IN_PATH = &where.exe nuget.exe
+    if ((Test-Path $NUGET_EXE_IN_PATH)) {
+        "Found $($NUGET_EXE_IN_PATH)"
+        $NUGET_EXE = $NUGET_EXE_IN_PATH 
+    }
+}
+
 # Try download NuGet.exe if not exists
 if (!(Test-Path $NUGET_EXE)) {
 	Invoke-WebRequest -Uri http://nuget.org/nuget.exe -OutFile $NUGET_EXE
@@ -18,6 +28,9 @@ if (!(Test-Path $NUGET_EXE)) {
 if (!(Test-Path $NUGET_EXE)) {
     Throw "Could not find NuGet.exe"
 }
+
+# Save nuget.exe path to environment to be available to child processed
+$ENV:NUGET_EXE = $NUGET_EXE
 
 # Restore tools from NuGet.
 Push-Location


### PR DESCRIPTION
Added option to try resolve nuget.exe from `path` if not found
Added storing nuget.exe path to environment variable `NUGET_EXE`

This requires cake supporting this as proposed in [Cake PR #141](https://github.com/cake-build/cake/pull/141) or that build.cake is adjusted like [this](https://github.com/WCOMAB/PiFaceServer/commit/b0f27e673c6acab1e11d1f71b5a8719bc71f964e#diff-4d3634747586b964df9f7712bc3ec669R54)

I.e. AppVeyor log will look something like this
```
Build started
2  git clone -q --branch=master git://github.com/WCOMAB/PiFaceServer.git C:\projects\pifaceserver
3  git checkout -qf b0f27e673c6acab1e11d1f71b5a8719bc71f964e
4  .\build.ps1
5  Trying to find nuget.exe in path
6  Found C:\Tools\NuGet\nuget.exe 
7  Installing 'Cake 0.1.24'.
8  Successfully installed 'Cake 0.1.24'.
```
