### PR TITLE
Install cake.nupkg and other tools packages into correct location

### DIFF
--- a/res/scripts/build.ps1
+++ b/res/scripts/build.ps1
@@ -115,13 +115,13 @@ if(-Not $SkipToolPackageRestore.IsPresent)
     # Restore packages
     if (Test-Path $PACKAGES_CONFIG)
     {
-        $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion"
+        $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
         Write-Verbose $NuGetOutput
     }
     # Install just Cake if missing config
     else
     {
-        $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install Cake -ExcludeVersion"
+        $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install Cake -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
         Write-Verbose $NuGetOutput
     }
     Pop-Location


### PR DESCRIPTION
Not sure how the package restore was working for others, but in my project (which has a root nuget.config file that specifies an explicit repositoryPath param) the tools packages were being restored into the wrong location. Make the restore output dir explicit to work around that problem.