### PR TITLE
Fixes "too many arguments" error when base directory contains spaces.

### DIFF
--- a/res/scripts/build.sh
+++ b/res/scripts/build.sh
@@ -32,14 +32,14 @@ for i in "$@"; do
 done
 
 # Make sure the tools folder exist.
-if [ ! -d $TOOLS_DIR ]; then
-  mkdir $TOOLS_DIR
+if [ ! -d "$TOOLS_DIR" ]; then
+  mkdir "$TOOLS_DIR"
 fi
 
 # Make sure that packages.config exist.
-if [ ! -f $TOOLS_DIR/packages.config ]; then
+if [ ! -f "$TOOLS_DIR/packages.config" ]; then
     echo "Downloading packages.config..."
-    curl -Lsfo $TOOLS_DIR/packages.config http://cakebuild.net/bootstrapper/packages
+    curl -Lsfo "$TOOLS_DIR/packages.config" http://cakebuild.net/bootstrapper/packages
     if [ $? -ne 0 ]; then
         echo "An error occured while downloading packages.config."
         exit 1
@@ -47,9 +47,9 @@ if [ ! -f $TOOLS_DIR/packages.config ]; then
 fi
 
 # Download NuGet if it does not exist.
-if [ ! -f $NUGET_EXE ]; then
+if [ ! -f "$NUGET_EXE" ]; then
     echo "Downloading NuGet..."
-    curl -Lsfo $NUGET_EXE https://www.nuget.org/nuget.exe
+    curl -Lsfo "$NUGET_EXE" https://www.nuget.org/nuget.exe
     if [ $? -ne 0 ]; then
         echo "An error occured while downloading nuget.exe."
         exit 1
@@ -57,8 +57,8 @@ if [ ! -f $NUGET_EXE ]; then
 fi
 
 # Restore tools from NuGet.
-pushd $TOOLS_DIR >/dev/null
-mono $NUGET_EXE install -ExcludeVersion
+pushd "$TOOLS_DIR" >/dev/null
+mono "$NUGET_EXE" install -ExcludeVersion
 if [ $? -ne 0 ]; then
     echo "Could not restore NuGet packages."
     exit 1
@@ -66,18 +66,18 @@ fi
 popd >/dev/null
 
 # Make sure that Cake has been installed.
-if [ ! -f $CAKE_EXE ]; then
+if [ ! -f "$CAKE_EXE" ]; then
     echo "Could not find Cake.exe at '$CAKE_EXE'."
     exit 1
 fi
 
 # Start Cake
 if $SHOW_VERSION; then
-    mono $CAKE_EXE -version
+    mono "$CAKE_EXE" -version
 elif $DRYRUN; then
-    mono $CAKE_EXE $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET -dryrun
+    mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET -dryrun
 else
-    mono $CAKE_EXE $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET
+    mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET
 fi
 
 exit $?


### PR DESCRIPTION
When running the bootstrapper under Linux in a directory that contains spaces, bootstrapping will fail. The error message given is below:

```
build.sh: line 35: [: too many arguments
build.sh: line 40: [: too many arguments
build.sh: line 50: [: too many arguments
``` 

The resolution is to quote all variables that can contain spaces (e.g. `$TOOLS_DIR`). 