### PR TITLE
Adds support for spaces in path to cake

### DIFF
--- a/res/scripts/build.ps1
+++ b/res/scripts/build.ps1
@@ -134,5 +134,5 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "$CAKE_EXE `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental"
 exit $LASTEXITCODE


### PR DESCRIPTION
With cake.exe in a path that contains spaces (like "C:\Users\Username\Documents\Visual Studio 2013\Projects\ConsoleApplication42\tools\Cake") build.ps1 fails to execute. This change fixes that issue.