### PR TITLE
Forward arguments from the boostrapper scripts

### DIFF
--- a/res/scripts/build.ps1
+++ b/res/scripts/build.ps1
@@ -39,7 +39,9 @@ Param(
     [switch]$WhatIf,
     [switch]$Mono,
     [switch]$SkipToolPackageRestore,
-    [switch]$Verbose
+    [switch]$Verbose,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$ScriptArgs
 )
 
 Write-Host "Preparing to run build script..."
@@ -136,5 +138,5 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
 exit $LASTEXITCODE

--- a/res/scripts/build.sh
+++ b/res/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ###############################################################
 # This is the Cake bootstrapper script that is responsible for
 # downloading Cake and all specified tools from NuGet.
@@ -15,8 +15,9 @@ SCRIPT="build.cake"
 TARGET="Default"
 CONFIGURATION="Release"
 VERBOSITY="verbose"
-DRYRUN=false
+DRYRUN=
 SHOW_VERSION=false
+SCRIPT_ARGUMENTS=()
 
 # Parse arguments.
 for i in "$@"; do
@@ -25,8 +26,10 @@ for i in "$@"; do
         -t|--target) TARGET="$2"; shift ;;
         -c|--configuration) CONFIGURATION="$2"; shift ;;
         -v|--verbosity) VERBOSITY="$2"; shift ;;
-        -d|--dryrun) DRYRUN=true ;;
+        -d|--dryrun) DRYRUN="-dryrun" ;;
         --version) SHOW_VERSION=true ;;
+        --) shift; SCRIPT_ARGUMENTS+=("$@"); break ;;
+        *) SCRIPT_ARGUMENTS+=("$1") ;;
     esac
     shift
 done
@@ -73,11 +76,7 @@ fi
 
 # Start Cake
 if $SHOW_VERSION; then
-    mono "$CAKE_EXE" -version
-elif $DRYRUN; then
-    mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET -dryrun
+    exec mono "$CAKE_EXE" -version
 else
-    mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET
+    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
 fi
-
-exit $?


### PR DESCRIPTION
Follow-up on cake-build/cake#605 by applying the changes to the default bootstrappers as well.

BTW, to prevent this sort of update-things-everywhere problem in the future, you guys may want to consider just replacing your build script with this:

```bash
#!/usr/bin/env bash

# Just call the script at another URL and forward all arguments
curl -Lsf http://cakebuild.net/bootstrapper/linux | bash -s -- "$@"
```

cc: @devlead 