### PR TITLE
Support PowerShell v2.0 also in the bootstrapper build script

### DIFF
--- a/res/scripts/build.ps1
+++ b/res/scripts/build.ps1
@@ -52,8 +52,10 @@ if($Verbose.IsPresent)
     $VerbosePreference = "continue"
 }
 
+$PS_SCRIPT_ROOT = split-path -parent $MyInvocation.MyCommand.Definition;
 $TOOLS_DIR = Join-Path $PSScriptRoot "tools"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
+$NUGET_URL = "http://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
 $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 
@@ -105,7 +107,9 @@ if (!(Test-Path $NUGET_EXE)) {
 # Try download NuGet.exe if not exists
 if (!(Test-Path $NUGET_EXE)) {
     Write-Verbose -Message "Downloading NuGet.exe..."
-    try { Invoke-WebRequest -Uri http://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile $NUGET_EXE } catch {
+    try {
+        (New-Object System.Net.WebClient).DownloadFile($NUGET_URL, $NUGET_EXE)
+    } catch {
         Throw "Could not download NuGet.exe."
     }
 }


### PR DESCRIPTION
- 'Invoke-WebRequest' is a function from PowerShell v3.0 onwards. To let
  the bootstrapper script work with PowerShell v2.0, use the
  System.Net.WebClient of the .NET framework instead.