### PR TITLE
Removed duplicate Verbose option from cmdlet.

### DIFF
--- a/res/scripts/build.ps1
+++ b/res/scripts/build.ps1
@@ -28,6 +28,7 @@ http://cakebuild.net
 
 #>
 
+[CmdletBinding()]
 Param(
     [string]$Script = "build.cake",
     [string]$Target = "Default",
@@ -39,18 +40,11 @@ Param(
     [switch]$WhatIf,
     [switch]$Mono,
     [switch]$SkipToolPackageRestore,
-    [switch]$Verbose,
     [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs
 )
 
 Write-Host "Preparing to run build script..."
-
-# Should we show verbose messages?
-if($Verbose.IsPresent)
-{
-    $VerbosePreference = "continue"
-}
 
 $PS_SCRIPT_ROOT = split-path -parent $MyInvocation.MyCommand.Definition;
 $TOOLS_DIR = Join-Path $PSScriptRoot "tools"


### PR DESCRIPTION
The "Parameter" attribute transforms a simple function into a complex one similar to using the "CmdletBinding" attribute (https://technet.microsoft.com/library/hh847743.aspx). This triggers the "-Verbose" parameter to be defined both implicitly and explicitly. The resulting erroneous behavior is described below:

Running:

`Invoke-WebRequest http://cakebuild.net/bootstrapper/windows -OutFile cake-bootstrap.ps1`
`.\cake-bootstrap.ps1`

Yields:

`<position> : A parameter with the name 'Verbose' was defined multiple times for the command.`

I added the "CmdletBinding" attribute to make it obvious that the function is advanced and removed the explicit definition of "Verbose".

Checked and confirmed that the functionality (setting VerbosePreference) is preserved by the implicit behavior.